### PR TITLE
fix(PreferenceFlow.android): add missing support for Long values in default SharedPreference based preference flow for android

### DIFF
--- a/preference/src/androidMain/kotlin/PreferenceFlow.android.kt
+++ b/preference/src/androidMain/kotlin/PreferenceFlow.android.kt
@@ -59,6 +59,7 @@ private var SharedPreferences.preferences: Preferences
                 when (mapValue) {
                     is Boolean -> putBoolean(key, mapValue)
                     is Int -> putInt(key, mapValue)
+                    is Long -> putLong(key, mapValue)
                     is Float -> putFloat(key, mapValue)
                     is String -> putString(key, mapValue)
                     is Set<*> ->


### PR DESCRIPTION

Fixes #24 

- [x] Tests pass (I'm using the library with this oneline update in android and its working fine) (tested on android only since change is limited to android)
- [x] Appropriate changes to README are included in PR (I don't think any update is required)